### PR TITLE
Trim down source distribution file size

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,27 @@
+## Include files/folders
+
 include pyproject.toml
-include LICENSE
-include CONTRIBUTING.md
 include README.md
+include LICENSE
+include CITATION.cff
+include *.cff  # citation info
+
+## Exclude individual files (non-hidden)
+exclude CONTRIBUTING.md
+exclude CODE_OF_CONDUCT.md
+exclude Makefile
+exclude mkdocs.yml
+exclude sonar-project.properties
+
+## Exclude individual files (hidden)
+exclude .pep8speaks.yml
+exclude .readthedocs.yaml
+exclude .pre-commit-config.yaml
+
+
+## Recursive exclude folders
 recursive-exclude * __pycache__
+recursive-exclude tests *
+recursive-exclude docs *
+recursive-exclude examples *
+recursive-exclude .github *


### PR DESCRIPTION
At present the gzipped source distribution is about `5 MB` (for `v0.2.0`). This seems a bit high, given the content of the source code. Mostly the `*.tar.gz` file is bloated with folders like `tests`, **`docs`**, `examples` that take up most of the space. From a user's perspective, none of these folders are part of the source-code. 

Although opinionated, for instance, documentation lives on the docs site; and making it part of the source code will only make the source code fatten up.

<sup>**`docs`**: this folder alone is almost 5 MB in size.</sup>

![image](https://user-images.githubusercontent.com/10201242/149246984-81c788fb-416e-49eb-b374-d01d11e79bb0.png)


#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

This PR updates the `MANIFEST.in` file to drop some of these from PyPI source:

- exclusively non-core-source code files
- folders like `tests`, `docs`, `examples` take up the most of space
- config-files that typically start with `.<something>.yml`, etc.

Fixes # (issue)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
	- [x] This will trim-down the source-package size

- [ ] This change requires a documentation update
	
	I am not sure about it; perhaps just a release note about this change would suffice. 


#### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation `NA`
- [x] My changes generate no new warnings
