### PR TITLE
Fix bug

### DIFF
--- a/chitra/coordinates.py
+++ b/chitra/coordinates.py
@@ -28,8 +28,8 @@ class BoundingBoxes:
             self.CORNER,
         ):
             raise AssertionError("bbox format must be either xyxy or xyhw")
-        bboxes = self._listify(bboxes, 4)
-        labels = self._listify(labels)
+        #bboxes = self._listify(bboxes)
+        #labels = self._listify(labels)
 
         if len(bboxes) != len(labels):
             raise UserWarning(f"len of boxes and labels not matching: {len(bboxes), len(labels)}")


### PR DESCRIPTION
This fixes the following bug:

When creating Chitra object  when the number of bounding boxes is 4, Chitra.__init__ complains that number of bounding boxes is 1 but number of labels is 4.

This is because when creating BoundingBox object, if the length of bounding box list is 4, it wrongly assumes it should be wrapped in a list.

I will be happy to discuss better solutions then this one. 

#### Changes
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Fixes # (issue)


#### Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Documentation Update
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


#### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
